### PR TITLE
Fetch size optimization can be applied by `ListingConfig.ORG_HIBERNAT…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Visual table summary? Want to know what's the most of something? No problem! You can acquire terms and statistics by just throwing attribute names into filter! Have a look at *Visual Table Summary* in this [UX Collective article](https://uxdesign.cc/design-better-data-tables-4ecc99d23356).
   * TO FUCKING DO!
+* Fetch size optimization can be applied by `ListingConfig.ORG_HIBERNATE_FETCHSIZE`, witch will add `typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.ORG_HIBERNATE_FETCHSIZE);` to the query if set.
 
 <a name="1.5.1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Features
 
 * Visual table summary? Want to know what's the most of something? No problem! You can acquire terms and statistics by just throwing attribute names into filter! Have a look at *Visual Table Summary* in this [UX Collective article](https://uxdesign.cc/design-better-data-tables-4ecc99d23356).
-  * TO FUCKING DO!
 * Fetch size optimization can be applied by `ListingConfig.ORG_HIBERNATE_FETCHSIZE`, witch will add `typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.ORG_HIBERNATE_FETCHSIZE);` to the query if set.
 
 <a name="1.5.1"></a>

--- a/src/main/java/io/coodoo/framework/listing/control/ListingConfig.java
+++ b/src/main/java/io/coodoo/framework/listing/control/ListingConfig.java
@@ -178,6 +178,19 @@ public class ListingConfig {
     public static ZoneId ZONE_ID = ZoneId.of(TIME_ZONE);
 
     /**
+     * <code>org.hibernate.fetchSize</code> tells the JDBC driver how many rows to return in one chunk, for large queries.<br>
+     * If this is set to <code>0</code> (default) it will not be applied. <br>
+     * <br>
+     * <i><code>org.hibernate.fetchSize</code> will do nothing if your driver does not support it!</i> <br>
+     * <br>
+     * Say you want 1000 rows. If you set the fetch size to 100, the database will return 100, then another 100 when you want more, and so on. <br>
+     * <br>
+     * You can also set this globally by adding <code>&lt;property name="hibernate.jdbc.fetch_size" value="100"/&gt; </code> to your options in
+     * <code>persitence.xml</code>
+     */
+    public static int ORG_HIBERNATE_FETCHSIZE = 0;
+
+    /**
      * Name of the (optional) listing property file
      */
     private static final String listingPropertiesFilename = "coodoo.listing.properties";
@@ -231,6 +244,7 @@ public class ListingConfig {
                 URI_DECODE = loadProperty(URI_DECODE, "coodoo.listing.uri.decode");
                 URI_CHARACTER_ENCODING = loadProperty(URI_CHARACTER_ENCODING, "coodoo.listing.uricharacterencoding");
 
+                ORG_HIBERNATE_FETCHSIZE = loadProperty(ORG_HIBERNATE_FETCHSIZE, "coodoo.listing.org.hibernate.fetchSize");
             }
         } catch (IOException e) {
             log.info("Couldn't read {}!", listingPropertiesFilename, e);

--- a/src/main/java/io/coodoo/framework/listing/control/ListingConfig.java
+++ b/src/main/java/io/coodoo/framework/listing/control/ListingConfig.java
@@ -178,7 +178,8 @@ public class ListingConfig {
     public static ZoneId ZONE_ID = ZoneId.of(TIME_ZONE);
 
     /**
-     * <code>org.hibernate.fetchSize</code> tells the JDBC driver how many rows to return in one chunk, for large queries.<br>
+     * The fetch size or better the option <code>org.hibernate.fetchSize</code> tells the JDBC driver how many rows to return in one chunk, for large
+     * queries.<br>
      * If this is set to <code>0</code> (default) it will not be applied. <br>
      * <br>
      * <i><code>org.hibernate.fetchSize</code> will do nothing if your driver does not support it!</i> <br>
@@ -188,7 +189,7 @@ public class ListingConfig {
      * You can also set this globally by adding <code>&lt;property name="hibernate.jdbc.fetch_size" value="100"/&gt; </code> to your options in
      * <code>persitence.xml</code>
      */
-    public static int ORG_HIBERNATE_FETCHSIZE = 0;
+    public static int FETCHSIZE = 0;
 
     /**
      * Name of the (optional) listing property file
@@ -244,7 +245,7 @@ public class ListingConfig {
                 URI_DECODE = loadProperty(URI_DECODE, "coodoo.listing.uri.decode");
                 URI_CHARACTER_ENCODING = loadProperty(URI_CHARACTER_ENCODING, "coodoo.listing.uricharacterencoding");
 
-                ORG_HIBERNATE_FETCHSIZE = loadProperty(ORG_HIBERNATE_FETCHSIZE, "coodoo.listing.org.hibernate.fetchSize");
+                FETCHSIZE = loadProperty(FETCHSIZE, "coodoo.listing.fetchSize");
             }
         } catch (IOException e) {
             log.info("Couldn't read {}!", listingPropertiesFilename, e);

--- a/src/main/java/io/coodoo/framework/listing/control/ListingQuery.java
+++ b/src/main/java/io/coodoo/framework/listing/control/ListingQuery.java
@@ -624,6 +624,9 @@ public class ListingQuery<T> {
         if (limit != null && limit > 0) {
             typedQuery.setMaxResults(limit);
         }
+        if (ListingConfig.ORG_HIBERNATE_FETCHSIZE != 0) {
+            typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.ORG_HIBERNATE_FETCHSIZE);
+        }
         return typedQuery.getResultList();
     }
 

--- a/src/main/java/io/coodoo/framework/listing/control/ListingQuery.java
+++ b/src/main/java/io/coodoo/framework/listing/control/ListingQuery.java
@@ -624,8 +624,8 @@ public class ListingQuery<T> {
         if (limit != null && limit > 0) {
             typedQuery.setMaxResults(limit);
         }
-        if (ListingConfig.ORG_HIBERNATE_FETCHSIZE != 0) {
-            typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.ORG_HIBERNATE_FETCHSIZE);
+        if (ListingConfig.FETCHSIZE != 0) {
+            typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.FETCHSIZE);
         }
         return typedQuery.getResultList();
     }


### PR DESCRIPTION
…E_FETCHSIZE`, witch will add `typedQuery.setHint("org.hibernate.fetchSize", ListingConfig.ORG_HIBERNATE_FETCHSIZE);` to the query if set.